### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LuxNeuralOperators
 
 LuxNeuralOperators are NeuralOperators built using [Lux.jl](https://lux.csail.mit.edu/).
-For a version built using an old-generation framework [Flux.jl](https://fluxml.ai/), see
+For a version built using the alternative deep learning framework [Flux.jl](https://fluxml.ai/), see
 [NeuralOperators.jl](https://docs.sciml.ai/NeuralOperators/stable/)


### PR DESCRIPTION
Flux is not an old-generation framework compared to Lux, the same way jax people wouldn't call pytorch old-generation just because it is a project started earlier. 