### PR TITLE
Update CI workflows for downgrade v2 (issue #1076)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,6 +50,7 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+          ALLOW_RERESOLVE: false
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
@@ -71,9 +72,10 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/julia-downgrade-compat@v1
+      - uses: julia-actions/julia-downgrade-compat@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+          ALLOW_RERESOLVE: false
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
## Summary
- Updates julia-downgrade-compat from @v1 to @v2
- Adds ALLOW_RERESOLVE: false to julia-runtest steps in downgrade jobs
- Addresses requirements from SciMLBase.jl issue #1076

## Changes Made
- Updated 1 CI workflow file(s)
- Ensures compatibility with downgrade v2 requirements
- Maintains existing test configurations and skip parameters

## Test plan
- [ ] Verify CI workflows continue to work with updated downgrade action
- [ ] Confirm ALLOW_RERESOLVE: false prevents re-resolution as intended
- [ ] Check that existing test groups and configurations are preserved

Fixes SciML/SciMLBase.jl#1076

🤖 Generated with [Claude Code](https://claude.ai/code)