### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -20,18 +20,7 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-        os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     with:
-      julia-version: "${{ matrix.version }}"
-      os: "${{ matrix.os }}"
+      coverage-directories: "src"
     secrets: "inherit"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using NeuralOperators, Test, ParallelTestRunner
 
+const GROUP = get(ENV, "GROUP", "All")
+
 parsed_args = parse_args(@isdefined(TEST_ARGS) ? TEST_ARGS : ARGS)
 
 # Find all tests
@@ -10,6 +12,20 @@ filter_tests!(testsuite, parsed_args)
 # Remove shared setup files that shouldn't be run directly
 delete!(testsuite, "shared_testsetup")
 delete!(testsuite, "layers/layers_testsetup")
+
+# Dispatch on the CI test GROUP. "QA" runs only the quality-assurance suite
+# (Aqua / ExplicitImports / doctests); "Core" runs the functional suite; "All"
+# (the default for a bare local `Pkg.test()`) runs everything.
+const QA_TESTS = ("qa_tests", "doctests")
+if GROUP == "QA"
+    for name in collect(keys(testsuite))
+        name in QA_TESTS || delete!(testsuite, name)
+    end
+elseif GROUP == "Core"
+    for name in QA_TESTS
+        delete!(testsuite, name)
+    end
+end
 
 total_jobs = min(
     something(parsed_args.jobs, ParallelTestRunner.default_njobs()), length(keys(testsuite))

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,6 @@
+[Core]
+versions = ["lts", "1", "pre"]
+os = ["ubuntu-latest", "windows-latest", "macos-latest"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the root test workflow (`Tests.yml`) to the canonical thin caller of `SciML/.github/.github/workflows/grouped-tests.yml@v1`, with the test matrix declared once in a root `test/test_groups.toml`.

- **`.github/workflows/Tests.yml`** — replaced the hand-maintained `version`/`os` matrix job with a thin `grouped-tests.yml@v1` caller. `on:` and `concurrency:` preserved verbatim; filename and `name:` kept. `coverage-directories: "src"` (this package has no `ext/`); everything else uses defaults (`GROUP` env, `check-bounds: yes`, coverage on).
- **`test/test_groups.toml`** (new) — `[Core]` on `lts`/`1`/`pre` across `ubuntu-latest`/`windows-latest`/`macos-latest`; `[QA]` on `lts`/`1`.
- **`test/runtests.jl`** — reads the `GROUP` env var and dispatches the `ParallelTestRunner` testsuite. `QA` runs only `qa_tests` (Aqua + ExplicitImports) and `doctests`; `Core` runs the functional layer/model suite; `All` (default for a bare local `Pkg.test()`) runs everything, so local workflows are unchanged.

Root `[compat] julia` was already `"1.10"` (LTS floor) and the package has no `[extras]` section (it uses `[workspace]`), so no `Project.toml` metadata fixes were required.

## Matrix match

The reusable matrix was statically computed via `scripts/compute_affected_sublibraries.jl . --root-matrix`:

- `Core`: `{lts, 1, pre}` × `{ubuntu-latest, windows-latest, macos-latest}` = 9 jobs
- `QA`: `{lts, 1}` × `ubuntu-latest` = 2 jobs

The old `Tests.yml` ran the whole suite on Julia `1` across `ubuntu`/`windows`/`macos` (3 jobs). Those exact cells are a subset of the new `Core` matrix, so the prior OS coverage is preserved; the conversion additionally standardizes the version axis to the canonical `lts`/`1`/`pre` set and wires the QA group as its own job.

## Notes

QA group is newly wired as a distinct CI job; Aqua/JET/ExplicitImports/doctests run in CI — any failures will be triaged in a follow-up.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)