### PR TITLE
Release prep: bump version to 0.6.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NeuralOperators"
 uuid = "ea5c82af-86e5-48da-8ee1-382d6ad7af4b"
 authors = ["Avik Pal <avikpal@mit.edu>"]
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
## Summary

Bumps the package version from 0.6.4 to 0.6.5 to register unreleased commits.

The last registered version (0.6.4) corresponds to commit bcb44f7 (tree-sha1 matches the General registry entry `cce4ca3ab64ad9724936ac3ece3ccfcb8039a5eb` exactly). Since then, one commit has landed on `main`:

- 65de156 — "Use SciMLTesting 2.1 QA docs check (#148)"

## What changed since 0.6.4

The diff (`bcb44f7..HEAD`) touches only test/CI/QA infrastructure:
- `test/Project.toml`: bump `SciMLTesting` compat from `"1"` to `"2.1"`
- `test/qa/Project.toml`: bump `SciMLTesting` compat from `"1.6"` to `"2.1"`, drop a `[sources]` path override for `NeuralOperators`
- `test/qa/qa_tests.jl`: add `api_docs_kwargs = (; rendered = true)` to the `run_qa` call

No changes to `src/`, no changes to the root `Project.toml` `[deps]`/`[compat]`, and no new/changed public API.

## Bump type

**PATCH** (0.6.4 → 0.6.5) — the change is test/QA-tooling only, with no source, dependency, or compat changes at the package level that affect consumers.

## Compat bounds

No SciML-ecosystem compat bounds were touched in the root `Project.toml` (it is byte-for-byte unchanged since 0.6.4). The only compat changes are to `SciMLTesting` in `test/Project.toml` and `test/qa/Project.toml`, which are test-only dependencies not part of the released package's compat surface.