### PR TITLE
test: run the precompile workload testset (and: the Windows julia-1 failure is upstream)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,10 +26,10 @@ withenv(
         @time @safetestset "SpectralKernel" begin
             include(joinpath(@__DIR__, "layers", "spectral_kernel_tests.jl"))
         end
-        return @time @safetestset "Transform Interface" begin
+        @time @safetestset "Transform Interface" begin
             include(joinpath(@__DIR__, "layers", "transform_interface_tests.jl"))
         end
-        @time @safetestset "Precompile workload" begin
+        return @time @safetestset "Precompile workload" begin
             include(joinpath(@__DIR__, "precompile_workload.jl"))
         end
     end


### PR DESCRIPTION
## Summary

Two separate things were investigated here; only one of them is an actual repo bug.

### 1. The failing `Core (julia 1, windows-latest)` lane is NOT caused by anything in this repo

The lane fails while precompiling **Reactant** (a `test/Project.toml` dependency loaded by
`test/shared_testsetup.jl`), not while running NeuralOperators code:

```
lld: error: undefined symbol: jl_cstr_to_string
>>> referenced by jl_50E6.tmp(text#0.o):(julia_call_with_reactant_54807u54810)
...
LoadError: failed process: Process(setenv(`...\julia\1.12.7\x64\libexec\julia\lld.exe' -flavor gnu -m i386pep ...
  -o 'C:\Users\runneradmin\.julia\compiled\v1.12\Reactant\jl_A381.tmp' ...`), ProcessExited(1))
in expression starting at ...\test\shared_testsetup.jl:1
in expression starting at ...\test\models\fno_tests.jl:3
```

Evidence that this is an environment/upstream regression rather than a regression from
`57cbb6c`/`eb240e7`/`1927dfb`:

* Last green Windows/`julia 1` job (run `31109559340`, commit `57cbb6c`, 2026-08-06) used
  **Julia 1.12.6** and **Reactant v0.2.278**. First red one (run `32005859786`, commit `eb240e7`,
  2026-08-17) used **Julia 1.12.7** and **Reactant v0.2.279**. Nothing in `eb240e7` touches
  Reactant, precompilation, or the test harness; it only adds a `SciMLTesting = "2.10"`
  compat entry.
* NeuralOperators itself precompiles fine on that lane at master HEAD
  (`24043.3 ms ✓ NeuralOperators`), including the new `@compile_workload`. The failure happens
  later, inside Reactant's own precompilation.
* **The isolating experiment already exists.** The `codex/ci-probe-clean-main-neuraloperators`
  probe (run `31919259681`, 2026-08-16, sha `4e52d06`) is `57cbb6c` plus a *comment-only* line in
  `Project.toml` — functionally the same tree as the last green run — and its
  `Core (julia 1, windows-latest)` job failed with the identical
  `lld: error: undefined symbol: jl_cstr_to_string`, on Julia 1.12.7 with Reactant v0.2.279.
  Same code, newer toolchain, red.
* The failure is deterministic, not a flake or a timeout: `lld: error: undefined symbol` appears
  three times in the same job (Julia's precompile retries) and in every run since 2026-08-16.
* The `julia lts` Windows lane (Julia 1.10) is green at HEAD, matching a Julia-1.12.7-specific
  codegen/linker problem.

So the Windows lane should not, by itself, block the release: the released code fails the same
way in the current environment. The fix belongs upstream (Reactant/Julia on Windows).

### 2. Real bug from #160: the new precompile-workload test never ran

`test/runtests.jl` gained the `"Precompile workload"` `@safetestset` *after*
`return @time @safetestset "Transform Interface" ... end`, so it was unreachable — the
regression test for the new `@compile_workload` was dead code in every group. This PR moves the
`return` to the last testset.

## Verification

* `julia --project=. -e 'using Pkg; Pkg.instantiate(); using NeuralOperators'` — the
  `@compile_workload` runs clean (`38715.0 ms ✓ NeuralOperators` on Julia 1.11.8, macOS aarch64).
* `julia --project=. -e 'include("test/precompile_workload.jl")'` — `3 passed`, so the newly
  reachable testset is green.
* `Runic --check test/runtests.jl` — clean.

No version bump here; the release pass handles that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
