### PR TITLE
Format for Runic v1.10

### DIFF
--- a/src/models/deeponet.jl
+++ b/src/models/deeponet.jl
@@ -123,18 +123,18 @@ function DeepONet(;
     branch_net = Chain(
         [
             Dense(
-                    branch[i] => branch[i + 1],
-                    ifelse(i == length(branch) - 1, identity, branch_activation),
-                ) for i in 1:(length(branch) - 1)
+                branch[i] => branch[i + 1],
+                ifelse(i == length(branch) - 1, identity, branch_activation),
+            ) for i in 1:(length(branch) - 1)
         ]...,
     )
 
     trunk_net = Chain(
         [
             Dense(
-                    trunk[i] => trunk[i + 1],
-                    ifelse(i == length(trunk) - 1, identity, trunk_activation),
-                ) for i in 1:(length(trunk) - 1)
+                trunk[i] => trunk[i + 1],
+                ifelse(i == length(trunk) - 1, identity, trunk_activation),
+            ) for i in 1:(length(trunk) - 1)
         ]...,
     )
 

--- a/src/models/fno.jl
+++ b/src/models/fno.jl
@@ -186,17 +186,17 @@ function FourierNeuralOperator(
     fno_blocks = Chain(
         [
             SpectralKernel(
-                    hidden_channels => hidden_channels,
-                    modes,
-                    activation;
-                    stabilizer,
-                    shift,
-                    use_channel_mlp,
-                    channel_mlp_expansion,
-                    channel_mlp_skip,
-                    fno_skip,
-                    complex_data,
-                ) for _ in 1:num_layers
+                hidden_channels => hidden_channels,
+                modes,
+                activation;
+                stabilizer,
+                shift,
+                use_channel_mlp,
+                channel_mlp_expansion,
+                channel_mlp_skip,
+                fno_skip,
+                complex_data,
+            ) for _ in 1:num_layers
         ]...,
     )
 


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `6e8855303903`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos src/models/deeponet.jl src/models/fno.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Doctests 1/1 passed; package tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Precompile workload 3/3 passed; package tests passed
```

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the source diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)