### PR TITLE
Drop x86 CI until Reactant Integer priority fix

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -2,11 +2,13 @@
 versions = ["lts", "1", "pre"]
 os = ["ubuntu-latest", "windows-latest", "macos-latest"]
 
-["Core 32-bit"]
-group = "Core"
-versions = ["1"]
-os = ["ubuntu-latest"]
-arch = "x86"
+# Core 32-bit dropped: Reactant CPU backend register_backend requires Int64
+# priority; bare `100` is Int32 on i686 (EnzymeAD/Reactant.jl#3274).
+# ["Core 32-bit"]
+# group = "Core"
+# versions = ["1"]
+# os = ["ubuntu-latest"]
+# arch = "x86"
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
## Summary
- x86 Core fails at `using Reactant` with `TypeError: priority expected Int64, got Int32` ([EnzymeAD/Reactant.jl#3274](https://github.com/EnzymeAD/Reactant.jl/pull/3274)).
- Drop the x86 lane until that fix is registered; re-enable afterward.

## Test plan
- [ ] Default-branch CI has no x86_only hard fail
- [ ] Re-enable `["Core 32-bit"]` after Reactant release

Made with [Cursor](https://cursor.com)